### PR TITLE
Fix namespace issues in some dashboards

### DIFF
--- a/grafana/RabbitMQ Channels Overview - Seventh State RabbitMQ Support.json
+++ b/grafana/RabbitMQ Channels Overview - Seventh State RabbitMQ Support.json
@@ -461,15 +461,16 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values($namespace,$namespace)",
+        "definition": "label_values(rabbitmq_identity_info,namespace)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
+        "label": "Namespace",
         "name": "namespace",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values($namespace,$namespace)",
+          "query": "label_values(rabbitmq_identity_info,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/grafana/RabbitMQ Connections Overview - Seventh State RabbitMQ Support.json
+++ b/grafana/RabbitMQ Connections Overview - Seventh State RabbitMQ Support.json
@@ -422,15 +422,16 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values($namespace,$namespace)",
+        "definition": "label_values(rabbitmq_identity_info,namespace)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
+        "label": "Namespace",
         "name": "namespace",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values($namespace,$namespace)",
+          "query": "label_values(rabbitmq_identity_info,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/grafana/RabbitMQ Queue Details - Seventh State RabbitMQ Support.json
+++ b/grafana/RabbitMQ Queue Details - Seventh State RabbitMQ Support.json
@@ -928,15 +928,16 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values($namespace,$namespace)",
+        "definition": "label_values(rabbitmq_identity_info,namespace)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
+        "label": "Namespace",
         "name": "namespace",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values($namespace,$namespace)",
+          "query": "label_values(rabbitmq_identity_info,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/grafana/RabbitMQ Queues Overview - Seventh State RabbitMQ Support.json
+++ b/grafana/RabbitMQ Queues Overview - Seventh State RabbitMQ Support.json
@@ -588,15 +588,15 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values($namespace,$namespace)",
-        "hide": 0,
+        "definition": "label_values(rabbitmq_identity_info,namespace)",
         "includeAll": false,
         "multi": false,
+        "label": "Namespace",
         "name": "namespace",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values($namespace,$namespace)",
+          "query": "label_values(rabbitmq_identity_info,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
- Updated namespace references in the following dashboards:
  - RabbitMQ Channels Overview
  - RabbitMQ Connections Overview
  - RabbitMQ Queue Details
  - RabbitMQ Queues Overview